### PR TITLE
Make @EdmFunctionImport work for functions that return entities

### DIFF
--- a/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/data/store/InMemoryDataStore.java
+++ b/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/data/store/InMemoryDataStore.java
@@ -274,6 +274,8 @@ public class InMemoryDataStore<T> implements DataStore<T> {
         return idCounter.getAndIncrement();
       } else if (type == Long.class || type == long.class) {
         return (long) idCounter.getAndIncrement();
+      } else if (type == UUID.class) {
+        return UUID.randomUUID();
       }
 
       throw new UnsupportedOperationException("Automated key generation for type '" + type

--- a/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/data/store/InMemoryDataStore.java
+++ b/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/data/store/InMemoryDataStore.java
@@ -118,16 +118,17 @@ public class InMemoryDataStore<T> implements DataStore<T> {
     return create(object, keyElement);
   }
 
-  private T create(final T object, final KeyElement keyElement) throws DataStoreException {
-    synchronized (dataStore) {
-      if (keyElement.keyValuesMissing() || dataStore.containsKey(keyElement)) {
-        KeyElement newKey = createSetAndGetKeys(object);
-        return this.create(object, newKey);
+    private T create(final T object, final KeyElement keyElement) throws DataStoreException {
+      synchronized (dataStore) {
+        final boolean replaceKeys = dataStore.containsKey(keyElement);
+        if (keyElement.keyValuesMissing() || replaceKeys) {
+          KeyElement newKey = createSetAndGetKeys(object, replaceKeys);
+          return this.create(object, newKey);
+        }
+        dataStore.put(keyElement, object);
       }
-      dataStore.put(keyElement, object);
+      return object;
     }
-    return object;
-  }
 
   @Override
   public T update(final T object) {
@@ -254,13 +255,16 @@ public class InMemoryDataStore<T> implements DataStore<T> {
       return keyElement;
     }
 
-    KeyElement createSetAndGetKeys(final T object) {
+    KeyElement createSetAndGetKeys(final T object, final boolean replaceKeys) {
       KeyElement keyElement = new KeyElement(keyFields.size());
-      for (Field field : keyFields) {
-        Object key = createKey(field);
-        ClassHelper.setFieldValue(object, field, key);
-        keyElement.addValue(key);
-      }
+        for (Field field : keyFields) {
+          Object key = ClassHelper.getFieldValue(object, field);
+          if (key == null || replaceKeys) {
+            key = createKey(field);
+            ClassHelper.setFieldValue(object, field, key);
+          }
+          keyElement.addValue(key);
+        }
 
       return keyElement;
     }
@@ -287,7 +291,7 @@ public class InMemoryDataStore<T> implements DataStore<T> {
     return keyAccess.getKeyValues(object);
   }
 
-  private KeyElement createSetAndGetKeys(final T object) throws DataStoreException {
-    return keyAccess.createSetAndGetKeys(object);
+  private KeyElement createSetAndGetKeys(final T object, final boolean replaceKeys) throws DataStoreException {
+    return keyAccess.createSetAndGetKeys(object, replaceKeys);
   }
 }

--- a/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelper.java
+++ b/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelper.java
@@ -719,20 +719,27 @@ public class AnnotationHelper {
         returnType.setTypeName(edmSimpleTypeKind.getFullQualifiedName());
         break;
       case ENTITY:
+        returnType.setTypeName(extractEntityTypeFqn(
+                determineAnnotatedClass(functionImport, annotatedMethod)));
+        break;
       case COMPLEX:
-        Class<?> annotatedClazz;
-        if (functionImport.returnType().isCollection()) {
-          ParameterizedType parameterizedType = (ParameterizedType) annotatedMethod.getGenericReturnType();
-          annotatedClazz = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-        } else {
-          annotatedClazz = annotatedMethod.getReturnType();
-        }
-        returnType.setTypeName(extractComplexTypeFqn(annotatedClazz));
+        returnType.setTypeName(extractComplexTypeFqn(
+                determineAnnotatedClass(functionImport, annotatedMethod)));
         break;
       default:
         throw new UnsupportedOperationException("Not yet supported return type type '" + functionImport.returnType().type() + "'.");
     }
     return returnType;
+  }
+
+  private Class<?> determineAnnotatedClass(final EdmFunctionImport functionImport,
+                                           final Method annotatedMethod) {
+    if (functionImport.returnType().isCollection()) {
+      ParameterizedType parameterizedType = (ParameterizedType) annotatedMethod.getGenericReturnType();
+      return (Class<?>) parameterizedType.getActualTypeArguments()[0];
+    } else {
+      return annotatedMethod.getReturnType();
+    }
   }
 
   public String extractEntitySetName(final Method annotatedMethod) {

--- a/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/data/store/AnnotationsDataSourceTest.java
+++ b/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/data/store/AnnotationsDataSourceTest.java
@@ -672,6 +672,39 @@ public class AnnotationsDataSourceTest {
   }
 
   @Test
+  public void createGuidKeyEntity() throws Exception {
+    EdmEntitySet edmEntitySet = createMockedEdmEntitySet(GuidKeyEntity.GUID_KEY_ENTITIES);
+
+    final String entityName = "Entity name";
+    GuidKeyEntity testEntity = new GuidKeyEntity();
+    testEntity.setName(entityName);
+    datasource.createData(edmEntitySet, testEntity);
+
+    ReadResult result = datasource.readData(edmEntitySet, ReadOptions.none());
+    GuidKeyEntity readEntity = (GuidKeyEntity) result.getFirst();
+    Assert.assertEquals(entityName, readEntity.getName());
+  }
+
+  @Test
+  public void createGuidKeyEntityWithOwnKey() throws Exception {
+    EdmEntitySet edmEntitySet = createMockedEdmEntitySet(GuidKeyEntity.GUID_KEY_ENTITIES);
+
+    final UUID entityId = UUID.randomUUID();
+    final String entityName = "Entity name";
+    GuidKeyEntity testEntity = new GuidKeyEntity();
+    testEntity.setId(entityId);
+    testEntity.setName(entityName);
+    datasource.createData(edmEntitySet, testEntity);
+
+    Map<String, Object> keys = new HashMap<String, Object>();
+    keys.put("Id", entityId);
+
+    GuidKeyEntity readEntity = (GuidKeyEntity) datasource.readData(edmEntitySet, keys);
+    Assert.assertEquals(entityId, readEntity.getId());
+    Assert.assertEquals(entityName, readEntity.getName());
+  }
+
+  @Test
   public void deleteSimpleEntity() throws Exception {
     EdmEntitySet edmEntitySet = createMockedEdmEntitySet("Buildings");
     DataStore<Building> datastore = datasource.getDataStore(Building.class);

--- a/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/model/GuidKeyEntity.java
+++ b/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/model/GuidKeyEntity.java
@@ -1,0 +1,40 @@
+package org.apache.olingo.odata2.janos.processor.core.model;
+
+import org.apache.olingo.odata2.api.annotation.edm.EdmEntitySet;
+import org.apache.olingo.odata2.api.annotation.edm.EdmEntityType;
+import org.apache.olingo.odata2.api.annotation.edm.EdmFacets;
+import org.apache.olingo.odata2.api.annotation.edm.EdmKey;
+import org.apache.olingo.odata2.api.annotation.edm.EdmProperty;
+import org.apache.olingo.odata2.api.annotation.edm.EdmType;
+
+import java.util.UUID;
+
+@EdmEntityType(name = "GuidKeyEntity", namespace = ModelSharedConstants.NAMESPACE_1)
+@EdmEntitySet(name = GuidKeyEntity.GUID_KEY_ENTITIES)
+public class GuidKeyEntity {
+
+  public static final String GUID_KEY_ENTITIES = "GuidKeyEntities";
+  @EdmProperty(name = "Id", type = EdmType.GUID, facets = @EdmFacets(nullable = false))
+  @EdmKey
+  protected UUID id;
+
+  @EdmProperty(name = "Name")
+  protected String name;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelperTest.java
+++ b/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelperTest.java
@@ -18,11 +18,13 @@ package org.apache.olingo.odata2.janos.processor.core.util;
 import junit.framework.Assert;
 import org.apache.olingo.odata2.api.annotation.edm.*;
 import org.apache.olingo.odata2.api.edm.FullQualifiedName;
+import org.apache.olingo.odata2.api.edm.provider.*;
 import org.apache.olingo.odata2.api.exception.ODataException;
 import org.apache.olingo.odata2.janos.processor.core.model.Location;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -237,6 +239,20 @@ public class AnnotationHelperTest {
     Assert.assertEquals(Byte.valueOf("1"), cp.byteProp);
   }
 
+  @Test
+  public void extractComplexReturnType() throws Exception {
+    Method method = FunctionExecutor.class.getMethod("findNames", String.class);
+    ReturnType returnType = annotationHelper.extractReturnType(method);
+    Assert.assertEquals("Names", returnType.getTypeName().getName());
+  }
+
+  @Test
+  public void extractEntityReturnType() throws Exception {
+    Method method = FunctionExecutor.class.getMethod("findSimple", String.class);
+    ReturnType returnType = annotationHelper.extractReturnType(method);
+    Assert.assertEquals("SimpleEntity", returnType.getTypeName().getName());
+  }
+
   @EdmEntityType
   private class SimpleEntity {
     @EdmKey
@@ -261,6 +277,31 @@ public class AnnotationHelperTest {
     SimpleEntity navigationPropertyDefault;
     @EdmNavigationProperty
     List<NavigationAnnotated> selfReferencedNavigation;
+  }
+
+  @EdmComplexType
+  private class Names {
+    @EdmProperty
+    String firstName;
+    @EdmProperty
+    String lastName;
+  }
+
+  private class FunctionExecutor {
+    @EdmFunctionImport(
+            returnType = @EdmFunctionImport.ReturnType(
+                    type = EdmFunctionImport.ReturnType.Type.COMPLEX))
+    public Names findNames(
+            @EdmFunctionImportParameter(name = "Name") final String name) {
+      return new Names();
+    }
+    @EdmFunctionImport(
+            returnType = @EdmFunctionImport.ReturnType(
+                    type = EdmFunctionImport.ReturnType.Type.ENTITY))
+    public SimpleEntity findSimple(
+            @EdmFunctionImportParameter(name = "Name") final String name) {
+      return new SimpleEntity(1L, name);
+    }
   }
 
   private class ConversionProperty {

--- a/janos-jpa-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/jpa/model/RefFunctions.java
+++ b/janos-jpa-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/jpa/model/RefFunctions.java
@@ -28,7 +28,7 @@ public class RefFunctions implements FunctionExecutor {
     dataStoreManager = dataStore;
   }
 
-  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.ENTITY))
+  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.COMPLEX))
   public City citySearch(@EdmFunctionImportParameter(name = "cityName", type = EdmType.STRING) String name) {
     try {
       DataStore<Employee> ds = dataStoreManager.getDataStore("Employees", Employee.class);

--- a/janos-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/model/RefFunctions.java
+++ b/janos-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/model/RefFunctions.java
@@ -28,7 +28,7 @@ public class RefFunctions implements FunctionExecutor {
     dataStoreManager = dataStore;
   }
 
-  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.ENTITY))
+  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.COMPLEX))
   public City citySearch(@EdmFunctionImportParameter(name = "cityName", type = EdmType.STRING) String name) {
     try {
       DataStore<Employee> ds = dataStoreManager.getDataStore("Employees", Employee.class);


### PR DESCRIPTION
`@EdmFunctionImport` only worked for functions that return complex types because those that return entities were not handled correctly by `AnnotationHelper`. This has been fixed.

The two reference `RefFunctions` classes needed to be fixed as well. They declared functions as returning entities when they actually returned complex types. After the changes to `AnnotationHelper` this error caused integration tests to fail.