### PR TITLE
Fix @EdmFunctionImport handling for functions that return entities

### DIFF
--- a/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelper.java
+++ b/janos-core/src/main/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelper.java
@@ -719,20 +719,27 @@ public class AnnotationHelper {
         returnType.setTypeName(edmSimpleTypeKind.getFullQualifiedName());
         break;
       case ENTITY:
+        returnType.setTypeName(extractEntityTypeFqn(
+                determineAnnotatedClass(functionImport, annotatedMethod)));
+        break;
       case COMPLEX:
-        Class<?> annotatedClazz;
-        if (functionImport.returnType().isCollection()) {
-          ParameterizedType parameterizedType = (ParameterizedType) annotatedMethod.getGenericReturnType();
-          annotatedClazz = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-        } else {
-          annotatedClazz = annotatedMethod.getReturnType();
-        }
-        returnType.setTypeName(extractComplexTypeFqn(annotatedClazz));
+        returnType.setTypeName(extractComplexTypeFqn(
+                determineAnnotatedClass(functionImport, annotatedMethod)));
         break;
       default:
         throw new UnsupportedOperationException("Not yet supported return type type '" + functionImport.returnType().type() + "'.");
     }
     return returnType;
+  }
+
+  private Class<?> determineAnnotatedClass(final EdmFunctionImport functionImport,
+                                           final Method annotatedMethod) {
+    if (functionImport.returnType().isCollection()) {
+      ParameterizedType parameterizedType = (ParameterizedType) annotatedMethod.getGenericReturnType();
+      return (Class<?>) parameterizedType.getActualTypeArguments()[0];
+    } else {
+      return annotatedMethod.getReturnType();
+    }
   }
 
   public String extractEntitySetName(final Method annotatedMethod) {

--- a/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelperTest.java
+++ b/janos-core/src/test/java/org/apache/olingo/odata2/janos/processor/core/util/AnnotationHelperTest.java
@@ -18,11 +18,13 @@ package org.apache.olingo.odata2.janos.processor.core.util;
 import junit.framework.Assert;
 import org.apache.olingo.odata2.api.annotation.edm.*;
 import org.apache.olingo.odata2.api.edm.FullQualifiedName;
+import org.apache.olingo.odata2.api.edm.provider.*;
 import org.apache.olingo.odata2.api.exception.ODataException;
 import org.apache.olingo.odata2.janos.processor.core.model.Location;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -237,6 +239,20 @@ public class AnnotationHelperTest {
     Assert.assertEquals(Byte.valueOf("1"), cp.byteProp);
   }
 
+  @Test
+  public void extractComplexReturnType() throws Exception {
+    Method method = FunctionExecutor.class.getMethod("findNames", String.class);
+    ReturnType returnType = annotationHelper.extractReturnType(method);
+    Assert.assertEquals("Names", returnType.getTypeName().getName());
+  }
+
+  @Test
+  public void extractEntityReturnType() throws Exception {
+    Method method = FunctionExecutor.class.getMethod("findSimple", String.class);
+    ReturnType returnType = annotationHelper.extractReturnType(method);
+    Assert.assertEquals("SimpleEntity", returnType.getTypeName().getName());
+  }
+
   @EdmEntityType
   private class SimpleEntity {
     @EdmKey
@@ -261,6 +277,31 @@ public class AnnotationHelperTest {
     SimpleEntity navigationPropertyDefault;
     @EdmNavigationProperty
     List<NavigationAnnotated> selfReferencedNavigation;
+  }
+
+  @EdmComplexType
+  private class Names {
+    @EdmProperty
+    String firstName;
+    @EdmProperty
+    String lastName;
+  }
+
+  private class FunctionExecutor {
+    @EdmFunctionImport(
+            returnType = @EdmFunctionImport.ReturnType(
+                    type = EdmFunctionImport.ReturnType.Type.COMPLEX))
+    public Names findNames(
+            @EdmFunctionImportParameter(name = "Name") final String name) {
+      return new Names();
+    }
+    @EdmFunctionImport(
+            returnType = @EdmFunctionImport.ReturnType(
+                    type = EdmFunctionImport.ReturnType.Type.ENTITY))
+    public SimpleEntity findSimple(
+            @EdmFunctionImportParameter(name = "Name") final String name) {
+      return new SimpleEntity(1L, name);
+    }
   }
 
   private class ConversionProperty {

--- a/janos-jpa-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/jpa/model/RefFunctions.java
+++ b/janos-jpa-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/jpa/model/RefFunctions.java
@@ -28,7 +28,7 @@ public class RefFunctions implements FunctionExecutor {
     dataStoreManager = dataStore;
   }
 
-  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.ENTITY))
+  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.COMPLEX))
   public City citySearch(@EdmFunctionImportParameter(name = "cityName", type = EdmType.STRING) String name) {
     try {
       DataStore<Employee> ds = dataStoreManager.getDataStore("Employees", Employee.class);

--- a/janos-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/model/RefFunctions.java
+++ b/janos-ref/src/main/java/org/apache/olingo/odata2/janos/processor/ref/model/RefFunctions.java
@@ -28,7 +28,7 @@ public class RefFunctions implements FunctionExecutor {
     dataStoreManager = dataStore;
   }
 
-  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.ENTITY))
+  @EdmFunctionImport(returnType = @ReturnType(type = ReturnType.Type.COMPLEX))
   public City citySearch(@EdmFunctionImportParameter(name = "cityName", type = EdmType.STRING) String name) {
     try {
       DataStore<Employee> ds = dataStoreManager.getDataStore("Employees", Employee.class);


### PR DESCRIPTION
`@EdmFunctionImport` only worked for functions that return complex types because those that return entities were not handled correctly by `AnnotationHelper`. This has been fixed.

The two reference `RefFunctions` classes needed to be fixed as well. They declared functions as returning entities when they actually returned complex types. After the changes to `AnnotationHelper` this error caused integration tests to fail.